### PR TITLE
Feat/search

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>ScottyB :)</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import Search from './components/Search';
 import Sidebar from './components/Sidebar';
 
 function App() {
-const [searchResults, setSearchResults] = useState("");
+const [searchResults, setSearchResults] = useState("IBM");
 
   return (
     <div className="flex">

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,17 @@
 import './App.css';
+import { useState } from 'react';
 import MainContent from './components/MainContent';
 import Search from './components/Search';
 import Sidebar from './components/Sidebar';
 
 function App() {
+const [searchResults, setSearchResults] = useState("");
+
   return (
     <div className="flex">
       <Sidebar />
-      <MainContent />
-      <Search />
+      <MainContent searchResults={searchResults} />
+      <Search setSearchResults={setSearchResults} />
     </div>
   );
 }

--- a/src/components/MainContent.js
+++ b/src/components/MainContent.js
@@ -61,8 +61,6 @@ export default function MainContent({ searchResults }) {
           createQtySHEquityDataPoints(balanceSheetData);
         })
         .catch((error) => console.log(error));
-
-      // MOCK DATA USED TO CHECK STYLING FOR DIFFERENT SYMBOLS SINCE API HAS 25 REQUEST/DAY LIMIT
     }
   }, [searchResults]);
 

--- a/src/components/MainContent.js
+++ b/src/components/MainContent.js
@@ -11,11 +11,10 @@ import {
   Legend
 } from "chart.js";
 
-
 // MOCK DATA USED TO CHECK STYLING FOR DIFFERENT SYMBOLS SINCE API HAS 25 REQUEST/DAY LIMIT
-// import SAICbs from "../mockData/SAIC-bs.json";
-// import SAICgi from "../mockData/SAIC-gi.json";
-// import SAICis from "../mockData/SAIC-id.json";
+import SAICbs from "../mockData/SAIC-bs.json";
+import SAICgi from "../mockData/SAIC-gi.json";
+import SAICis from "../mockData/SAIC-id.json";
 
 ChartJS.register(
   CategoryScale,
@@ -27,8 +26,7 @@ ChartJS.register(
   Legend
 );
 
-
-export default function MainContent() {
+export default function MainContent({ searchResults }) {
   const [companyInfo, setCompanyInfo] = useState({});
   const [graphLabels, setGraphLabels] = useState([]);
   const [qtrlyNetIncome, setQtrylNetIncome] = useState([]);
@@ -36,40 +34,37 @@ export default function MainContent() {
   const [qtrylSHEquity, setQtrylSHEquity] = useState([]);
 
   useEffect(() => {
-    const generalCompanyInfo =
-      "https://www.alphavantage.co/query?function=OVERVIEW&symbol=IBM&apikey=demo";
-    const incomeStatement =
-      "https://www.alphavantage.co/query?function=INCOME_STATEMENT&symbol=IBM&apikey=demo";
-    const balanceSheet =
-      "https://www.alphavantage.co/query?function=BALANCE_SHEET&symbol=IBM&apikey=demo";
+    if (searchResults === "SAIC") {
+      createCompanyInfo(SAICgi);
+      createGraphLabels(SAICis);
+      createQuarterlyNetIncomePoints(SAICis);
+      createQuarterlyTotalRevenuePoints(SAICis);
+      createQtySHEquityDataPoints(SAICbs);
+    } else {
+      const generalCompanyInfo = `https://www.alphavantage.co/query?function=OVERVIEW&symbol=${searchResults}&apikey=demo`;
+      const incomeStatement = `https://www.alphavantage.co/query?function=INCOME_STATEMENT&symbol=${searchResults}&apikey=demo`;
+      const balanceSheet = `https://www.alphavantage.co/query?function=BALANCE_SHEET&symbol=${searchResults}&apikey=demo`;
 
-    Promise.all([
-      fetch(incomeStatement).then((res) => res.json()),
-      fetch(balanceSheet).then((res) => res.json()),
-      fetch(generalCompanyInfo).then((res) => res.json())
-    ])
-      .then((data) => {
-        const incomeStatementData = data[0];
-        const balanceSheetData = data[1];
-        const companyData = data[2];
-        createCompanyInfo(companyData);
-        createGraphLabels(incomeStatementData);
-        createQuarterlyNetIncomePoints(incomeStatementData);
-        createQuarterlyTotalRevenuePoints(incomeStatementData);
-        createQtySHEquityDataPoints(balanceSheetData);
-      })
-      .catch((error) => console.log(error));
+      Promise.all([
+        fetch(incomeStatement).then((res) => res.json()),
+        fetch(balanceSheet).then((res) => res.json()),
+        fetch(generalCompanyInfo).then((res) => res.json())
+      ])
+        .then((data) => {
+          const incomeStatementData = data[0];
+          const balanceSheetData = data[1];
+          const companyData = data[2];
+          createCompanyInfo(companyData);
+          createGraphLabels(incomeStatementData);
+          createQuarterlyNetIncomePoints(incomeStatementData);
+          createQuarterlyTotalRevenuePoints(incomeStatementData);
+          createQtySHEquityDataPoints(balanceSheetData);
+        })
+        .catch((error) => console.log(error));
 
-
-// MOCK DATA USED TO CHECK STYLING FOR DIFFERENT SYMBOLS SINCE API HAS 25 REQUEST/DAY LIMIT
-    // createCompanyInfo(SAICgi);
-    // createGraphLabels(SAICis);
-    // createQuarterlyNetIncomePoints(SAICis);
-    // createQuarterlyTotalRevenuePoints(SAICis);
-    // createQtySHEquityDataPoints(SAICbs);
-
-
-  }, []);
+      // MOCK DATA USED TO CHECK STYLING FOR DIFFERENT SYMBOLS SINCE API HAS 25 REQUEST/DAY LIMIT
+    }
+  }, [searchResults]);
 
   const createCompanyInfo = (data) => {
     setCompanyInfo({
@@ -218,15 +213,19 @@ export default function MainContent() {
       <h1 className="text-2xl text-left pt-4 ml-10">Visualization Page</h1>
 
       {/* general info section */}
-      <div className="flex w-full justify-around items-start text-left">
+      <div className="flex w-full max-h-20 justify-around items-start text-left">
         <div className="w-10 h-10 bg-blue-900"></div>
         <div>
           <h2 className="font-extrabold">{companyInfo?.symbol}</h2>
-          <p className="text-gray-custom max-w-56">{companyInfo?.name}</p>
+          <p className="text-gray-custom max-w-56 max-h-20 overflow-hidden text-ellipsis">
+            {companyInfo?.name}
+          </p>
         </div>
         <div>
           <h3 className="text-gray-custom ">Industry</h3>
-          <p className="font-bold max-w-56">{companyInfo?.industry}</p>
+          <p className="font-bold max-w-56 text-ellipsis">
+            {companyInfo?.industry}
+          </p>
         </div>
         <div>
           <h3 className="text-gray-custom">Sector</h3>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,58 +1,64 @@
 import { useState } from "react";
-import searchSuggestions from "../mockData/SAIC-search.json";
+// import searchSuggestions fr om "../mockData/SAIC-search.json";
 
-export default function Search( {setSearchResults} ) {
+export default function Search({ setSearchResults }) {
+  const [userSearchInput, setUserSearchInput] = useState("");
+  const [searchSuggestions, setSearchSuggestions] = useState([]);
 
-    const [userSearchInput, setUserSearchInput] = useState("")
-    const [searchSuggestions, setSearchSuggestions] = useState([])
+  const handleSearch = (userInput) => {
+    const url = `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${userInput}&apikey=demo`;
 
-    const handleSearch = (userInput) => {
-    
-        const url = `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${userInput}&apikey=demo`
+    fetch(url)
+      .then((res) => res.json())
+      .then((data) => {
+        setSearchSuggestions(data.bestMatches);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
+  const handleSelect = (e) => {
+    setSearchResults(e.target.innerText);
+  };
 
-        fetch(url)
-            .then((res) => res.json())
-            .then((data) => {
-                setSearchSuggestions(data.bestMatches)
-            })
-            .catch((err) => {
-                console.error(err)
-            })
-    }
-
-    const handleSelect = (e) => {
-        console.log(e.target.value)
-        setSearchResults(e.target.value)
-    }
-
-    const createSearchResults = () => {
-        return searchSuggestions?.map((company) => {
-            return <button onClick={handleSelect} key={company["1. symbol"]} value={company["1. symbol"]}>{company["2. name"]}</button>
-        })
-    }
+  const createSearchResults = () => {
+    return searchSuggestions?.map((company) => {
+      return (
+        <li
+          className="w-5/6 font-bold cursor-pointer shadow-lg bg-blue-200 hover:bg-blue-300 hover:scale-105 border-2 rounded-lg"
+          onClick={(e) => handleSelect(e)}
+          key={company["1. symbol"]}>
+          {company["1. symbol"]}
+        </li>
+      );
+    });
+  };
 
   return (
-    <div className="w-1/4 flex flex-col items-center mb-5">
-      <button className=" w-1/2 rounded-lg h-10 mt-4 border-2 border-blue-900 hover:bg-blue-400">
+    <div className="w-1/4 h-screen flex flex-col items-center pb-5">
+      <button className=" w-1/2 rounded-lg h-10 mt-3 border-2 border-blue-900 hover:bg-blue-100 hover:scale-105 mb-6">
         Leave Feedback
       </button>
-      <div className="mt-20 w-4/5 h-5/6 border-2 border-blue-900 rounded-lg  pt-5">
-            <h2 className="text-2xl text-center">Search</h2>
-        <div className="flex items-start justify-center gap-2">
-          <input type="text" placeholder="Search Company" onChange={(e) => setUserSearchInput(e.target.value)}></input>
-          <button onClick={handleSearch(userSearchInput)} className="w-20 bg-white rounded-lg hover:bg-blue-400">
+      <div className="mt-20 w-4/5 h-auto border-2 border-blue-900 rounded-lg pb-5">
+        <h2 className="bg-blue-900 text-gray-custom text-2xl text-center pb-3 pt-2">
+          Search Ticker
+        </h2>
+        <div className="flex flex-col items-center gap-2 mt-2">
+          <input
+            type="text"
+            placeholder="Search Company"
+            value={userSearchInput}
+            onChange={(e) => setUserSearchInput(e.target.value.toUpperCase())}
+            className="w-3/4 h-10 border border-text-gray-custom rounded-lg hover:scale-105"></input>
+          <button
+            onClick={() => handleSearch(userSearchInput)}
+            className="w-20 bg-white rounded-lg border border-blue-900 hover:bg-blue-100 hover:scale-105">
             Search
           </button>
         </div>
         <div className="flex flex-col items-center">
-          <h2 className="text-2xl mt-5">Search Results</h2>
-          <ul className="flex flex-col gap-2 mt-5">
+          <ul className="flex flex-col items-center text-center gap-4 mt-5 w-full">
             {createSearchResults()}
-            {/* <button onClick={handleSelect} value="IBM">Apple</button>
-            <li>Amazon</li>
-            <li>Google</li>
-            <li>Facebook</li>
-            <li>Microsoft</li> */}
           </ul>
         </div>
       </div>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,25 +1,58 @@
-export default function Search() {
+import { useState } from "react";
+import searchSuggestions from "../mockData/SAIC-search.json";
+
+export default function Search( {setSearchResults} ) {
+
+    const [userSearchInput, setUserSearchInput] = useState("")
+    const [searchSuggestions, setSearchSuggestions] = useState([])
+
+    const handleSearch = (userInput) => {
+    
+        const url = `https://www.alphavantage.co/query?function=SYMBOL_SEARCH&keywords=${userInput}&apikey=demo`
+
+        fetch(url)
+            .then((res) => res.json())
+            .then((data) => {
+                setSearchSuggestions(data.bestMatches)
+            })
+            .catch((err) => {
+                console.error(err)
+            })
+    }
+
+    const handleSelect = (e) => {
+        console.log(e.target.value)
+        setSearchResults(e.target.value)
+    }
+
+    const createSearchResults = () => {
+        return searchSuggestions?.map((company) => {
+            return <button onClick={handleSelect} key={company["1. symbol"]} value={company["1. symbol"]}>{company["2. name"]}</button>
+        })
+    }
+
   return (
-    <div className="w-1/4 flex flex-col items-center">
+    <div className="w-1/4 flex flex-col items-center mb-5">
       <button className=" w-1/2 rounded-lg h-10 mt-4 border-2 border-blue-900 hover:bg-blue-400">
         Leave Feedback
       </button>
       <div className="mt-20 w-4/5 h-5/6 border-2 border-blue-900 rounded-lg  pt-5">
             <h2 className="text-2xl text-center">Search</h2>
         <div className="flex items-start justify-center gap-2">
-          <input type="text" placeholder="Search Company"></input>
-          <button className="w-20 bg-white rounded-lg hover:bg-blue-400">
+          <input type="text" placeholder="Search Company" onChange={(e) => setUserSearchInput(e.target.value)}></input>
+          <button onClick={handleSearch(userSearchInput)} className="w-20 bg-white rounded-lg hover:bg-blue-400">
             Search
           </button>
         </div>
         <div className="flex flex-col items-center">
           <h2 className="text-2xl mt-5">Search Results</h2>
           <ul className="flex flex-col gap-2 mt-5">
-            <li>Apple</li>
+            {createSearchResults()}
+            {/* <button onClick={handleSelect} value="IBM">Apple</button>
             <li>Amazon</li>
             <li>Google</li>
             <li>Facebook</li>
-            <li>Microsoft</li>
+            <li>Microsoft</li> */}
           </ul>
         </div>
       </div>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,5 +1,4 @@
 import { useState } from "react";
-// import searchSuggestions fr om "../mockData/SAIC-search.json";
 
 export default function Search({ setSearchResults }) {
   const [userSearchInput, setUserSearchInput] = useState("");


### PR DESCRIPTION
## What I did:
Create Search component where a user can search for a Ticker and display search results. Then a user can click on the ticker to update general company info and line graph.

## Notes:
My api endpoint only allows for 25 request per day. Currently when the page loads, the user will see data for IBM which is retrieved from the demo api provided by Alpha Vantage. When a user searches for a company ticker, the current free api endpoint that is connected is for "SAIC". When a user clicks on SAIC in the search results, this will update state in App.js which will trigger a re-render for company info and the line graph which is using stored "SAIC" data in a json object in my "mock data" folder. 

Currently have it set up this way to show functionality for when a user searches a different company that the page updates accordingly. Before site goes live, I will update API's keys to my personal key.

This PR closes #9 

### Did this break anything?

- [x] No
- [ ]  Yes

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
